### PR TITLE
super admin codes & root pw change cmds

### DIFF
--- a/cmd/cli/code.go
+++ b/cmd/cli/code.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"fmt"
+	"github.com/jrapoport/gothic/hosts/rpc"
+	"google.golang.org/grpc/metadata"
 	"os"
 	"strconv"
 
@@ -51,7 +53,9 @@ func codeRunE(_ *cobra.Command, args []string) error {
 		conn.Close()
 	}()
 	client := admin.NewAdminClient(conn)
-	ctx := context.Background()
+	pw := c.RootPassword
+	ctx := metadata.NewOutgoingContext(context.Background(),
+		metadata.Pairs(rpc.RootPassword, pw))
 	res, err := client.CreateSignupCodes(ctx, &admin.CreateSignupCodesRequest{
 		Uses:  int64(codeUses),
 		Count: int64(count),

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -1,9 +1,11 @@
 package main
 
-import "github.com/jrapoport/gothic/log"
+import (
+	"fmt"
+)
 
 func main() {
 	if err := ExecuteRoot(); err != nil {
-		log.Fatal(err)
+		fmt.Printf("Error: %s\n\n", err)
 	}
 }

--- a/cmd/cli/migrate.go
+++ b/cmd/cli/migrate.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"fmt"
+
 	"github.com/jrapoport/gothic/store"
 	"github.com/spf13/cobra"
 )
 
+// this command requires direct DB access
 var migrateCmd = &cobra.Command{
 	Use:  "migrate",
 	Long: "migrates the database",
@@ -17,16 +20,19 @@ func init() {
 
 func migrateRunE(cmd *cobra.Command, _ []string) error {
 	c := rootConfig()
-	l := c.Log().WithName("exe" + cmd.Use)
-	conn, err := store.Dial(c, l)
+	err := c.DB.CheckRequired()
 	if err != nil {
 		return err
 	}
-	l.Info("starting migration...")
+	conn, err := store.Dial(c, nil)
+	if err != nil {
+		return err
+	}
+	fmt.Println("starting migration...")
 	err = conn.AutoMigrate()
 	if err != nil {
 		return err
 	}
-	l.Info("migration complete")
+	fmt.Println("migration complete")
 	return nil
 }

--- a/cmd/cli/password.go
+++ b/cmd/cli/password.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/jrapoport/gothic/core/users"
+	"github.com/jrapoport/gothic/models/user"
+	"github.com/jrapoport/gothic/store"
+	"github.com/jrapoport/gothic/utils"
+	"github.com/spf13/cobra"
+)
+
+// this command requires direct DB access
+var passwordCmd = &cobra.Command{
+	Use:  "password [old] [new]",
+	Long: "password changes the root password",
+	RunE: passwordRunE,
+	Args: cobra.ExactArgs(2),
+}
+
+func init() {
+	AddRootCommand(passwordCmd)
+}
+
+func passwordRunE(cmd *cobra.Command, args []string) error {
+	var (
+		oldPassword = args[0]
+		newPassword = args[1]
+	)
+	c := rootConfig()
+	err := c.DB.CheckRequired()
+	if err != nil {
+		return err
+	}
+	conn, err := store.Dial(c, nil)
+	if err != nil {
+		return err
+	}
+	fmt.Println("changing root password...")
+	su, err := users.GetUser(conn, user.SuperAdminID)
+	if err != nil {
+		return err
+	}
+	err = su.Authenticate(oldPassword)
+	if err != nil {
+		return err
+	}
+	hash := utils.HashPassword(newPassword)
+	err = conn.Model(su).Update("password", hash).Error
+	if err != nil {
+		return err
+	}
+	fmt.Println("root password changed")
+	return nil
+}

--- a/cmd/exe/main.go
+++ b/cmd/exe/main.go
@@ -1,9 +1,9 @@
 package main
 
-import "github.com/jrapoport/gothic/log"
+import "fmt"
 
 func main() {
 	if err := ExecuteRoot(); err != nil {
-		log.Fatal(err)
+		fmt.Printf("Error: %s\n\n", err)
 	}
 }

--- a/config/database.go
+++ b/config/database.go
@@ -17,13 +17,20 @@ type Database struct {
 }
 
 func (d *Database) normalize(srv Service) (err error) {
+	if d.DSN == "" {
+		return nil
+	}
+	name := utils.Namespaced(d.Namespace, srv.Name)
+	_, d.DSN, err = drivers.NormalizeDSN(name, d.Driver, d.DSN)
+	return
+}
+
+func (d *Database) CheckRequired() error {
 	if d.Driver == "" {
 		return errors.New("database driver required")
 	}
 	if d.DSN == "" {
 		return errors.New("database dsn required")
 	}
-	name := utils.Namespaced(d.Namespace, srv.Name)
-	_, d.DSN, err = drivers.NormalizeDSN(name, d.Driver, d.DSN)
-	return
+	return nil
 }

--- a/config/env.go
+++ b/config/env.go
@@ -53,15 +53,11 @@ func loadEnv() (*viper.Viper, error) {
 	// set default values in viper.
 	// Viper needs to know if a key exists in order to override it.
 	// https://github.com/spf13/viper/issues/188
-	b, err := yaml.Marshal(configDefaults)
-	if err != nil {
-		return nil, err
-	}
+	// we can safely ignore this error because we control the struct
+	b, _ := yaml.Marshal(configDefaults)
 	defaults := map[string]interface{}{}
-	err = yaml.Unmarshal(b, &defaults)
-	if err != nil {
-		return nil, err
-	}
+	// we can safely ignore this error because we control the struct
+	_ = yaml.Unmarshal(b, &defaults)
 	v.SetTypeByDefaultValue(true)
 	for key, val := range defaults {
 		v.SetDefault(key, val)

--- a/config/network.go
+++ b/config/network.go
@@ -1,6 +1,8 @@
 package config
 
-import "net"
+import (
+	"net"
+)
 
 // HealthCheck is the health check route to use.
 const HealthCheck = "/health"
@@ -31,48 +33,31 @@ type Network struct {
 	RequestID string `json:"request_id" yaml:"request_id" mapstructure:"request_id"`
 }
 
-func (n *Network) normalize(Service) (err error) {
+func (n *Network) normalize(Service) {
 	dc := networkDefaults
 	if n.Host == dc.Host {
 		return
 	}
-	updateHost := func(addr, host string) (string, error) {
-		var p string
-		_, p, err = net.SplitHostPort(addr)
-		if err != nil {
-			return "", err
-		}
-		return net.JoinHostPort(host, p), nil
+	updateHost := func(addr, host string) string {
+		// we can safely ignore this error because we are
+		// always parsing our own default address.
+		_, p, _ := net.SplitHostPort(addr)
+		return net.JoinHostPort(host, p)
 	}
 	if n.RPCAddress == dc.RPCAddress {
-		n.RPCAddress, err = updateHost(n.RPCAddress, n.Host)
-		if err != nil {
-			return
-		}
+		n.RPCAddress = updateHost(n.RPCAddress, n.Host)
 	}
 	if n.AdminAddress == dc.AdminAddress {
-		n.AdminAddress, err = updateHost(n.AdminAddress, n.Host)
-		if err != nil {
-			return
-		}
+		n.AdminAddress = updateHost(n.AdminAddress, n.Host)
 	}
 	if n.RESTAddress == dc.RESTAddress {
-		n.RESTAddress, err = updateHost(n.RESTAddress, n.Host)
-		if err != nil {
-			return
-		}
+		n.RESTAddress = updateHost(n.RESTAddress, n.Host)
 	}
 	if n.RPCWebAddress == dc.RPCWebAddress {
-		n.RPCWebAddress, err = updateHost(n.RPCWebAddress, n.Host)
-		if err != nil {
-			return
-		}
+		n.RPCWebAddress = updateHost(n.RPCWebAddress, n.Host)
 	}
 	if n.HealthAddress == dc.HealthAddress {
-		n.HealthAddress, err = updateHost(n.HealthAddress, n.Host)
-		if err != nil {
-			return
-		}
+		n.HealthAddress = updateHost(n.HealthAddress, n.Host)
 	}
 	return
 }

--- a/config/network_test.go
+++ b/config/network_test.go
@@ -114,8 +114,7 @@ func TestNetwork_Normalization(t *testing.T) {
 		n.RPCWebAddress = test.uRPCWeb
 		n.AdminAddress = test.uRPC
 		n.HealthAddress = test.uRPC
-		err := n.normalize(serviceDefaults)
-		assert.NoError(t, err)
+		n.normalize(serviceDefaults)
 		assert.Equal(t, test.nHost, n.Host)
 		assert.Equal(t, test.nRest, n.RESTAddress)
 		assert.Equal(t, test.nRPC, n.RPCAddress)
@@ -123,26 +122,4 @@ func TestNetwork_Normalization(t *testing.T) {
 		assert.Equal(t, test.nRPC, n.AdminAddress)
 		assert.Equal(t, test.nRPC, n.HealthAddress)
 	}
-	n := Network{}
-	networkDefaults.HealthAddress = "::"
-	networkDefaults.RPCWebAddress = "::"
-	networkDefaults.RPCAddress = "::"
-	networkDefaults.AdminAddress = "::"
-	networkDefaults.RESTAddress = "::"
-	n.Host = "::"
-	n.HealthAddress = "::"
-	err := n.normalize(serviceDefaults)
-	assert.Error(t, err)
-	n.RPCWebAddress = "::"
-	err = n.normalize(serviceDefaults)
-	assert.Error(t, err)
-	n.RPCAddress = "::"
-	err = n.normalize(serviceDefaults)
-	assert.Error(t, err)
-	n.AdminAddress = "::"
-	err = n.normalize(serviceDefaults)
-	assert.Error(t, err)
-	n.RESTAddress = "::"
-	err = n.normalize(serviceDefaults)
-	assert.Error(t, err)
 }

--- a/config/options.go
+++ b/config/options.go
@@ -1,0 +1,32 @@
+package config
+
+type configOptions struct {
+	required bool
+}
+
+var defaultOptions = configOptions{
+	required: true,
+}
+
+type Option interface {
+	apply(*configOptions)
+}
+
+type funcOption struct {
+	f func(*configOptions)
+}
+
+func newFuncOption(f func(*configOptions)) *funcOption {
+	return &funcOption{
+		f: f,
+	}
+}
+func (fdo *funcOption) apply(do *configOptions) {
+	fdo.f(do)
+}
+
+func SkipRequired() Option {
+	return newFuncOption(func(o *configOptions) {
+		o.required = false
+	})
+}

--- a/config/secruity.go
+++ b/config/secruity.go
@@ -29,16 +29,10 @@ type Security struct {
 }
 
 func (s *Security) normalize(srv Service) error {
-	if s.RootPassword == "" {
-		return errors.New("root password is required")
-	}
-	err := s.JWT.normalize(srv, jwtDefaults)
-	if err != nil {
-		return err
-	}
+	s.JWT.normalize(srv, jwtDefaults)
 	userRx := s.Validation.UsernameRegex
 	if userRx != "" {
-		_, err = regexp.Compile(userRx)
+		_, err := regexp.Compile(userRx)
 		if err != nil {
 			err = fmt.Errorf("invalid username regex %s: %s", userRx, err)
 			return err
@@ -46,7 +40,7 @@ func (s *Security) normalize(srv Service) error {
 	}
 	passRx := s.Validation.PasswordRegex
 	if passRx != "" {
-		_, err = regexp.Compile(passRx)
+		_, err := regexp.Compile(passRx)
 		if err != nil {
 			err = fmt.Errorf("invalid password regex %s: %s", passRx, err)
 			return err
@@ -54,6 +48,13 @@ func (s *Security) normalize(srv Service) error {
 	}
 	if s.Cookies.Duration == 0 {
 		s.Cookies.Duration = cookieDuration
+	}
+	return nil
+}
+
+func (s *Security) CheckRequired() error {
+	if s.RootPassword == "" {
+		return errors.New("root password is required")
 	}
 	return nil
 }
@@ -70,16 +71,16 @@ type JWT struct {
 	Expiration time.Duration `json:"expiration"`
 }
 
-func (j *JWT) normalize(srv Service, def JWT) error {
+func (j *JWT) normalize(srv Service, def JWT) {
 	if def.Issuer == "" {
 		def.Issuer = strings.ToLower(srv.Name)
 	}
-	err := mergo.Merge(j, def)
-	if err != nil {
-		return err
-	}
-	// this needs to stay here
-	// so validation will happen correctly
+	// no error is possible here since we
+	// control the struct entirely
+	_ = mergo.Merge(j, def)
+}
+
+func (j *JWT) CheckRequired() error {
 	if j.Secret == "" {
 		return errors.New("jwt secret is required")
 	}

--- a/config/service.go
+++ b/config/service.go
@@ -20,9 +20,6 @@ func (s Service) Version() string {
 }
 
 func (s *Service) normalize() error {
-	if s.SiteURL == "" {
-		return errors.New("site url is required")
-	}
 	// make sure this wasn't mucked with
 	uri, err := url.Parse(s.SiteURL)
 	if err != nil {
@@ -30,6 +27,13 @@ func (s *Service) normalize() error {
 	}
 	if s.Name == "" {
 		s.Name = strings.ToLower(uri.Host)
+	}
+	return nil
+}
+
+func (s *Service) CheckRequired() error {
+	if s.SiteURL == "" {
+		return errors.New("site url is required")
 	}
 	return nil
 }

--- a/config/webhooks.go
+++ b/config/webhooks.go
@@ -19,11 +19,11 @@ type Webhooks struct {
 	JWT        `yaml:",inline" mapstructure:",squash"`
 }
 
-func (w *Webhooks) normalize(srv Service, j JWT) (err error) {
+func (w *Webhooks) normalize(srv Service, j JWT) error {
 	if w.URL == "" {
 		return nil
 	}
-	_, err = url.Parse(w.URL)
+	_, err := url.Parse(w.URL)
 	if err != nil {
 		return err
 	}
@@ -34,7 +34,8 @@ func (w *Webhooks) normalize(srv Service, j JWT) (err error) {
 		w.Events = []events.Event{events.All}
 		break
 	}
-	return w.JWT.normalize(srv, j)
+	w.JWT.normalize(srv, j)
+	return nil
 }
 
 // Enabled returns true if the enabled.

--- a/core/codes.go
+++ b/core/codes.go
@@ -1,6 +1,8 @@
 package core
 
 import (
+	"errors"
+
 	"github.com/google/uuid"
 	"github.com/jrapoport/gothic/core/audit"
 	"github.com/jrapoport/gothic/core/codes"
@@ -29,9 +31,14 @@ func (a *API) CreateSignupCode(ctx context.Context, uses int) (string, error) {
 
 // CreateSignupCodes returns a list of new signup pin codes.
 func (a *API) CreateSignupCodes(ctx context.Context, uses, count int) ([]string, error) {
+	aid := ctx.AdminID()
+	if aid == uuid.Nil {
+		err := errors.New("admin user id required")
+		return nil, a.logError(err)
+	}
 	var list []string
 	err := a.conn.Transaction(func(tx *store.Connection) error {
-		cl, err := codes.CreateSignupCodes(tx, user.SystemID, code.PIN, uses, count)
+		cl, err := codes.CreateSignupCodes(tx, aid, code.PIN, uses, count)
 		if err != nil {
 			return err
 		}

--- a/core/codes_test.go
+++ b/core/codes_test.go
@@ -3,6 +3,7 @@ package core
 import (
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/jrapoport/gothic/models/code"
 	"github.com/stretchr/testify/assert"
 )
@@ -22,6 +23,9 @@ func TestAPI_CreateCodes(t *testing.T) {
 	a := createAPI(t)
 	ctx := testContext(a)
 	list, err := a.CreateSignupCodes(ctx, code.SingleUse, count)
+	assert.Error(t, err)
+	ctx.SetAdminID(uuid.New())
+	list, err = a.CreateSignupCodes(ctx, code.SingleUse, count)
 	assert.NoError(t, err)
 	assert.Len(t, list, count)
 	assertUnique(t, list)

--- a/core/tokens/jwt/user.go
+++ b/core/tokens/jwt/user.go
@@ -25,7 +25,7 @@ var _ Claims = (*UserClaims)(nil)
 
 // NewUserClaims returns a new set of claims for the user.
 func NewUserClaims(u *user.User) *UserClaims {
-	if u == nil {
+	if u == nil || u.ID == user.SuperAdminID {
 		return nil
 	}
 	c := &UserClaims{
@@ -42,7 +42,7 @@ func NewUserClaims(u *user.User) *UserClaims {
 // UserID returns the jwt subject as a uuid.
 func (c UserClaims) UserID() uuid.UUID {
 	uid, err := uuid.Parse(c.Subject())
-	if err != nil {
+	if err != nil || uid == user.SuperAdminID {
 		return uuid.Nil
 	}
 	return uid

--- a/env/dev.env
+++ b/env/dev.env
@@ -4,13 +4,13 @@ ENV_FILE=./env/dev.env
 
 # Required
 GOTHIC_SITE_URL=https://example.com
-GOTHIC_ROOT_PASSWORD="IMPORTANT! CHANGE ME"
-GOTHIC_JWT_SECRET="IMPORTANT! CHANGE ME"
+GOTHIC_ROOT_PASSWORD="password"
+GOTHIC_JWT_SECRET="secret"
 
 GOTHIC_HOST=localhost
 
 GOTHIC_DB_DRIVER=mysql
-GOTHIC_DB_DSN="root@tcp(mysql_db:3306)/dev?parseTime=true"
+GOTHIC_DB_DSN="root@tcp(localhost:3306)/dev?parseTime=true"
 GOTHIC_DB_AUTOMIGRATE=true
 
 GOTHIC_LOG_LEVEL=info

--- a/hosts/rest/account/blackbox_test.go
+++ b/hosts/rest/account/blackbox_test.go
@@ -3,6 +3,7 @@ package account_test
 import (
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
@@ -72,7 +73,10 @@ func TestAccountServer(t *testing.T) {
 	// resend confirmation email
 	act := template.ConfirmUserAction
 	var confirmToken string
+	var mu sync.Mutex
 	smtp.AddHook(t, func(email string) {
+		mu.Lock()
+		defer mu.Unlock()
 		confirmToken = tconf.GetEmailToken(act, email)
 	})
 	cr := &confirm.Request{
@@ -105,6 +109,8 @@ func TestAccountServer(t *testing.T) {
 	var passToken string
 	act = template.ResetPasswordAction
 	smtp.AddHook(t, func(email string) {
+		mu.Lock()
+		defer mu.Unlock()
 		passToken = tconf.GetEmailToken(act, email)
 	})
 	route = account.Account + password.Password + password.Reset

--- a/hosts/rest/admin/codes/codes.go
+++ b/hosts/rest/admin/codes/codes.go
@@ -61,7 +61,7 @@ func (s *codesServer) CreateSignupCodes(w http.ResponseWriter, r *http.Request) 
 		s.ResponseCode(w, http.StatusUnprocessableEntity, err)
 		return
 	}
-	err = s.ValidateAdmin(r)
+	_, err = s.ValidateAdmin(r)
 	if err != nil {
 		s.ResponseCode(w, http.StatusUnauthorized, err)
 		return

--- a/hosts/rest/admin/users/users.go
+++ b/hosts/rest/admin/users/users.go
@@ -70,7 +70,7 @@ func (s *usersServer) GetUser(w http.ResponseWriter, r *http.Request) {
 		s.ResponseCode(w, http.StatusBadRequest, err)
 		return
 	}
-	err = s.ValidateAdmin(r)
+	_, err = s.ValidateAdmin(r)
 	if err != nil {
 		s.ResponseCode(w, http.StatusUnauthorized, err)
 		return
@@ -100,7 +100,7 @@ func (s *usersServer) UpdateUser(w http.ResponseWriter, r *http.Request) {
 		s.ResponseCode(w, http.StatusUnprocessableEntity, err)
 		return
 	}
-	err = s.ValidateAdmin(r)
+	_, err = s.ValidateAdmin(r)
 	if err != nil {
 		s.ResponseCode(w, http.StatusUnauthorized, err)
 		return
@@ -125,7 +125,7 @@ func (s *usersServer) AdminDeleteUser(w http.ResponseWriter, r *http.Request) {
 		s.ResponseCode(w, http.StatusBadRequest, err)
 		return
 	}
-	err = s.ValidateAdmin(r)
+	_, err = s.ValidateAdmin(r)
 	if err != nil {
 		s.ResponseCode(w, http.StatusUnauthorized, err)
 		return
@@ -149,7 +149,7 @@ func (s *usersServer) AdminPromoteUser(w http.ResponseWriter, r *http.Request) {
 		s.ResponseCode(w, http.StatusBadRequest, err)
 		return
 	}
-	err = s.ValidateAdmin(r)
+	_, err = s.ValidateAdmin(r)
 	if err != nil {
 		s.ResponseCode(w, http.StatusUnauthorized, err)
 		return

--- a/hosts/rest/server.go
+++ b/hosts/rest/server.go
@@ -1,11 +1,11 @@
 package rest
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/jrapoport/gothic/core"
 	"github.com/jrapoport/gothic/core/tokens"
+	"github.com/jrapoport/gothic/models/user"
 	"github.com/jrapoport/gothic/store"
 	"github.com/segmentio/encoding/json"
 )
@@ -26,20 +26,16 @@ func (s *Server) Clone() *Server {
 }
 
 // ValidateAdmin re-checks that a token belongs to an active admin user
-func (s *Server) ValidateAdmin(r *http.Request) error {
+func (s *Server) ValidateAdmin(r *http.Request) (user.Role, error) {
 	aid, err := GetUserID(r)
 	if err != nil {
-		return err
+		return user.InvalidRole, err
 	}
-	adm, err := s.GetAuthenticatedUser(aid)
+	role, err := s.API.ValidateAdmin(aid)
 	if err != nil {
-		return err
+		return user.InvalidRole, err
 	}
-	if !adm.IsAdmin() {
-		err = fmt.Errorf("admin required: %s", adm.ID)
-		return err
-	}
-	return nil
+	return role, nil
 }
 
 // Response wraps an http JSONContent response. If v is an

--- a/hosts/rpc/admin/admin_test.go
+++ b/hosts/rpc/admin/admin_test.go
@@ -7,6 +7,7 @@ import (
 	rpc_admin "github.com/jrapoport/gothic/api/grpc/rpc/admin"
 	"github.com/jrapoport/gothic/hosts/rpc"
 	"github.com/jrapoport/gothic/hosts/rpc/admin"
+	"github.com/jrapoport/gothic/test/tcore"
 	"github.com/jrapoport/gothic/test/tsrv"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -34,11 +35,13 @@ func TestAdminServer_Codes(t *testing.T) {
 	t.Parallel()
 	srv, _ := tsrv.RPCHost(t, []rpc.RegisterServer{
 		admin.RegisterServer,
-	})
+	}, rpc.Authentication())
 	client := tsrv.RPCClient(t, srv.Address(), func(cc grpc.ClientConnInterface) interface{} {
 		return rpc_admin.NewAdminClient(cc)
 	}).(rpc_admin.AdminClient)
-	ctx := context.Background()
+	_, tok := tcore.TestUser(t, srv.API, "", true)
+	ctx := tsrv.RPCAuthContext(t, srv.Config(), tok)
+	// authenticated call (success)
 	list, err := client.CreateSignupCodes(ctx, &rpc_admin.CreateSignupCodesRequest{
 		Uses:  1,
 		Count: 1,

--- a/hosts/rpc/admin/codes.go
+++ b/hosts/rpc/admin/codes.go
@@ -19,6 +19,19 @@ func (s *adminServer) CreateSignupCodes(ctx context.Context,
 		return nil, s.RPCError(codes.InvalidArgument, nil)
 	}
 	rtx := rpc.RequestContext(ctx)
+	pw := rpc.GetRootPassword(ctx)
+	if pw != "" {
+		sa, err := s.API.GetSuperAdmin(pw)
+		if err != nil {
+			return nil, s.RPCError(codes.PermissionDenied, err)
+		}
+		rtx.SetProvider(sa.Provider)
+		rtx.SetAdminID(sa.ID)
+	}
+	_, err := s.API.ValidateAdmin(rtx.AdminID())
+	if err != nil {
+		return nil, s.RPCError(codes.PermissionDenied, err)
+	}
 	uses := int(req.GetUses())
 	count := int(req.GetCount())
 	s.Debugf("create signup codes: %v", req)

--- a/hosts/rpc/request.go
+++ b/hosts/rpc/request.go
@@ -18,6 +18,7 @@ const (
 	RealIP         = "X-Real-IP"
 	ForwardedFor   = "X-Forwarded-For"
 	ReCaptchaToken = "X-ReCaptcha-Token"
+	RootPassword   = "X-Root-Password"
 )
 
 // RequestContext adds the request context to a context
@@ -39,6 +40,14 @@ func RequestContext(ctx context.Context) core_ctx.Context {
 		rtx.SetReCaptcha(v)
 	}
 	return rtx
+}
+
+func GetRootPassword(ctx context.Context) string {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return ""
+	}
+	return getMetadata(md, RootPassword)
 }
 
 // GetRemoteIP returns the remote ip from the context.

--- a/hosts/rpc/server.go
+++ b/hosts/rpc/server.go
@@ -1,7 +1,10 @@
 package rpc
 
 import (
+	"context"
+
 	"github.com/jrapoport/gothic/core"
+	"github.com/jrapoport/gothic/models/user"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -16,16 +19,18 @@ func NewServer(s *core.Server) *Server {
 	return &Server{s}
 }
 
-/*
-func (s *Server) Response(in interface{}, out interface{}) error {
-	b, err := json.Marshal(in)
+// ValidateAdmin re-checks that a token belongs to an active admin user
+func (s *Server) ValidateAdmin(ctx context.Context) (user.Role, error) {
+	aid, err := GetUserID(ctx)
 	if err != nil {
-		return s.RPCError(codes.Internal, err)
+		return user.InvalidRole, err
 	}
-	err = json.Unmarshal(b, out)
-	return s.RPCError(codes.Internal, err)
+	role, err := s.API.ValidateAdmin(aid)
+	if err != nil {
+		return user.InvalidRole, err
+	}
+	return role, nil
 }
-*/
 
 // RPCError wraps an rpc error code.
 func (s *Server) RPCError(c codes.Code, err error) error {

--- a/hosts/rpc/system/system.go
+++ b/hosts/rpc/system/system.go
@@ -37,7 +37,7 @@ func RegisterServer(s *grpc.Server, srv *rpc.Server) {
 	system.RegisterSystemServer(s, newSystemServer(srv))
 }
 
-func (s *systemServer) GetUser(_ context.Context, req *system.UserAccountRequest) (*system.UserAccountResponse, error) {
+func (s *systemServer) GetUserAccount(_ context.Context, req *system.UserAccountRequest) (*system.UserAccountResponse, error) {
 	var u *user.User
 	switch msg := req.GetId().(type) {
 	case *system.UserAccountRequest_UserId:

--- a/hosts/rpc/system/system_test.go
+++ b/hosts/rpc/system/system_test.go
@@ -30,24 +30,24 @@ func TestSystemServer_GetUser(t *testing.T) {
 	ctx := context.Background()
 	// no id or email
 	req := &system.UserAccountRequest{}
-	_, err := srv.GetUser(ctx, req)
+	_, err := srv.GetUserAccount(ctx, req)
 	assert.Error(t, err)
 	// bad id
 	req.Id = &system.UserAccountRequest_UserId{UserId: "1"}
-	_, err = srv.GetUser(ctx, req)
+	_, err = srv.GetUserAccount(ctx, req)
 	assert.Error(t, err)
 	// id not found
 	req.Id = &system.UserAccountRequest_UserId{
 		UserId: uuid.New().String(),
 	}
-	_, err = srv.GetUser(ctx, req)
+	_, err = srv.GetUserAccount(ctx, req)
 	assert.Error(t, err)
 	// success
 	u, _ := tcore.TestUser(t, srv.API, "", false)
 	req.Id = &system.UserAccountRequest_UserId{
 		UserId: u.ID.String(),
 	}
-	res, err := srv.GetUser(ctx, req)
+	res, err := srv.GetUserAccount(ctx, req)
 	assert.NoError(t, err)
 	assert.Equal(t, u.ID.String(), res.Id)
 	assert.Equal(t, u.Email, res.Email)
@@ -57,19 +57,19 @@ func TestSystemServer_GetUser(t *testing.T) {
 	req.Id = &system.UserAccountRequest_Email{
 		Email: "@",
 	}
-	_, err = srv.GetUser(ctx, req)
+	_, err = srv.GetUserAccount(ctx, req)
 	assert.Error(t, err)
 	// email not found
 	req.Id = &system.UserAccountRequest_Email{
 		Email: tutils.RandomEmail(),
 	}
-	_, err = srv.GetUser(ctx, req)
+	_, err = srv.GetUserAccount(ctx, req)
 	assert.Error(t, err)
 	// success
 	req.Id = &system.UserAccountRequest_Email{
 		Email: u.Email,
 	}
-	res, err = srv.GetUser(ctx, req)
+	res, err = srv.GetUserAccount(ctx, req)
 	assert.NoError(t, err)
 	assert.Equal(t, u.ID.String(), res.Id)
 	assert.Equal(t, u.Email, res.Email)

--- a/hosts/rpc_test.go
+++ b/hosts/rpc_test.go
@@ -1,10 +1,23 @@
 package hosts
 
-/*
-func configClient(t *testing.T, h core.Hosted) settings.SettingsClient {
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jrapoport/gothic/api/grpc/rpc/system"
+	"github.com/jrapoport/gothic/core"
+	"github.com/jrapoport/gothic/test/tcore"
+	"github.com/jrapoport/gothic/test/tsrv"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+func systemClient(t *testing.T, h core.Hosted) system.SystemClient {
 	return tsrv.RPCClient(t, h.Address(), func(cc grpc.ClientConnInterface) interface{} {
-		return settings.NewSettingsClient(cc)
-	}).(settings.SettingsClient)
+		return system.NewSystemClient(cc)
+	}).(system.SystemClient)
 }
 
 func TestRPCHost(t *testing.T) {
@@ -17,20 +30,18 @@ func TestRPCHost(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Eventually(t, func() bool {
 		return h.Online()
-	},1*time.Second, 10*time.Millisecond)
-	test := a.Settings()
-	// unauthenticated call
-	ctx := context.Background()
-	ac := configClient(t, h)
-	res, err := ac.Settings(ctx, &settings.SettingsRequest{})
+	}, 1*time.Second, 10*time.Millisecond)
+	u, _ := tcore.TestUser(t, a, "", false)
+	req := &system.UserAccountRequest{}
+	req.Id = &system.UserAccountRequest_UserId{UserId: u.ID.String()}
+	sc := systemClient(t, h)
+	res, err := sc.GetUserAccount(context.Background(), req)
 	assert.NoError(t, err)
-	assert.Equal(t, test.Status, res.Status)
-	assert.Equal(t, test.Signup.Provider.Internal, res.Signup.Provider.Internal)
+	assert.Equal(t, u.Email, res.Email)
 	// shut down
 	err = h.Shutdown()
 	assert.NoError(t, err)
 	assert.Eventually(t, func() bool {
 		return !h.Online()
-	},1*time.Second, 10*time.Millisecond)
+	}, 1*time.Second, 10*time.Millisecond)
 }
-*/

--- a/test/tconf/smtp.go
+++ b/test/tconf/smtp.go
@@ -81,6 +81,8 @@ func MockSMTP(t *testing.T, c *config.Config) (*config.Config, *SMTPMock) {
 				func(e *mail.Envelope, task backends.SelectTask) (backends.Result, error) {
 					if task == backends.TaskSaveMail {
 						mock.hooks.Range(func(_, value interface{}) bool {
+							mu.Lock()
+							defer mu.Unlock()
 							hook := value.(func(string))
 							hook(e.Data.String())
 							return true

--- a/test/tsrv/rpc.go
+++ b/test/tsrv/rpc.go
@@ -22,9 +22,9 @@ func RPCServer(t *testing.T, smtp bool) (*rpc.Server, *tconf.SMTPMock) {
 }
 
 // RPCHost an rpc server for tests.
-func RPCHost(t *testing.T, reg []rpc.RegisterServer) (*rpc.Host, *tconf.SMTPMock) {
+func RPCHost(t *testing.T, reg []rpc.RegisterServer, opt ...grpc.ServerOption) (*rpc.Host, *tconf.SMTPMock) {
 	a, _, mock := tcore.API(t, true)
-	h := rpc.NewHost(a, "test-rpc", "127.0.0.1:0", reg)
+	h := rpc.NewHost(a, "test-rpc", "127.0.0.1:0", reg, opt...)
 	err := h.ListenAndServe()
 	require.NoError(t, err)
 	t.Cleanup(func() {


### PR DESCRIPTION
required config shouldn't apply to cli
create sign codes supports super admin access
gadmin code cmd  runs as super admin & uses root password
gadmin pasword cmd changes root password (required direct db access)
other fixes